### PR TITLE
fix: exporting `LockRequest`

### DIFF
--- a/src/LockBox.ts
+++ b/src/LockBox.ts
@@ -1,13 +1,7 @@
 import type { ResourceAcquire, ResourceRelease } from '@matrixai/resources';
-import type { Lockable, ToString } from './types';
+import type { Lockable, ToString, LockRequest } from './types';
 import { withF, withG } from '@matrixai/resources';
 import { ErrorAsyncLocksLockBoxConflict } from './errors';
-
-type LockRequest<L extends Lockable> = [
-  key: ToString,
-  lockConstructor: new () => L,
-  ...lockingParams: Parameters<L['lock']>,
-];
 
 class LockBox<L extends Lockable> implements Lockable {
   protected _locks: Map<string, L> = new Map();

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,10 @@ interface Lockable {
   ): AsyncGenerator<T, TReturn, TNext>;
 }
 
-export type { POJO, ToString, Lockable };
+type LockRequest<L extends Lockable = Lockable> = [
+  key: ToString,
+  lockConstructor: new () => L,
+  ...lockingParams: Parameters<L['lock']>,
+];
+
+export type { POJO, ToString, Lockable, LockRequest };

--- a/tests/LockBox.test.ts
+++ b/tests/LockBox.test.ts
@@ -1,3 +1,4 @@
+import type { LockRequest } from '@/types';
 import { withF, withG } from '@matrixai/resources';
 import LockBox from '@/LockBox';
 import Lock from '@/Lock';
@@ -333,5 +334,17 @@ describe(LockBox.name, () => {
       })(),
     ]);
     expect(value).toBe(2);
+  });
+  test('can map keys to LockBox locks', async () => {
+    const lockBox = new LockBox();
+    const keys = ['1', '2', '3', '4'];
+    const locks: Array<LockRequest<RWLockWriter>> = keys.map((key) => [
+      key,
+      RWLockWriter,
+      'write',
+    ]);
+    await lockBox.withF(...locks, async () => {
+      // NOP
+    });
   });
 });


### PR DESCRIPTION
### Description
This exports the `LockRequest` type for use outside of this lib. It was mainly to fix the need to manually add the type in js-polykey. 

### Issues Fixed
* related matrixai/js-polykey#374

### Tasks

* [x] 1. Move `LockRequest` type to `./types`

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
